### PR TITLE
fix_parent_loop: set node parent only after checking conditions

### DIFF
--- a/examples/Graph/example2.php
+++ b/examples/Graph/example2.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace JMGQ\AStar\Example\Graph;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+/*
+This example hangs on v1.1.0.
+fix_parent_loop patch to Algorithm.php causes this example to work.
+    -- robin@pathwayi.com
+*/
+
+$nodes=array(
+	"nodestart" => new MyNode(0, 0),
+	"node1" => new MyNode(2, 5),
+	"nodegoal" => new MyNode(6, 4)
+);
+
+
+$links = array(
+
+//    new Link($nodes["nodestart"] , $nodes["nodegoal"], 6 ),
+//    new Link($nodes["nodegoal"] , $nodes["nodestart"], 6 ),
+
+    new Link($nodes["nodestart"] , $nodes["node1"], 6 ),
+    new Link($nodes["node1"] , $nodes["nodestart"], 6 ),
+
+    new Link($nodes["node1"] , $nodes["nodegoal"], 23 ),
+   new Link($nodes["nodegoal"] , $nodes["node1"], 23 )
+);
+$graph = new Graph($links);
+
+$start = $nodes["nodestart"];
+$goal = $nodes["nodegoal"];
+
+$aStar = new MyAStar($graph);
+$solution = $aStar->run($start, $goal);
+
+
+$printer = new SequencePrinter($graph, $solution);
+$printer->printSequence();
+
+echo "\n";

--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -84,7 +84,7 @@ abstract class Algorithm
                 break;
             }
 
-            $successors = $this->computeAdjacentNodes($currentNode, $goal);
+	    $successors = $this->generateAdjacentNodes($currentNode);
 
             foreach ($successors as $successor) {
                 if ($this->getOpenList()->contains($successor)) {
@@ -102,6 +102,11 @@ abstract class Algorithm
                         continue;
                     }
                 }
+
+		// after confirming, update the successor node
+            	$successor->setParent($currentNode);
+            	$successor->setG($currentNode->getG() + $this->calculateRealCost($currentNode, $successor));
+            	$successor->setH($this->calculateEstimatedCost($successor, $goal));
 
                 $this->getClosedList()->remove($successor);
 
@@ -127,16 +132,4 @@ abstract class Algorithm
         return $path;
     }
 
-    private function computeAdjacentNodes(Node $node, Node $goal)
-    {
-        $nodes = $this->generateAdjacentNodes($node);
-
-        foreach ($nodes as $adjacentNode) {
-            $adjacentNode->setParent($node);
-            $adjacentNode->setG($node->getG() + $this->calculateRealCost($node, $adjacentNode));
-            $adjacentNode->setH($this->calculateEstimatedCost($adjacentNode, $goal));
-        }
-
-        return $nodes;
-    }
-}
+ }


### PR DESCRIPTION
As per https://github.com/jmgq/php-a-star/issues/2

example2.php is the new test case, which hangs before the patch, but runs correctly after it.

In Algorithm.php, Successor node parent is now not updated until checks are done regarding open/closed lists and scores. 

-- robin@pathwayi.com
