### PR TITLE
Correct Return Type of getIterator()

### DIFF
--- a/src/Node/Collection/NodeHashTable.php
+++ b/src/Node/Collection/NodeHashTable.php
@@ -18,7 +18,7 @@ class NodeHashTable implements \IteratorAggregate, NodeCollectionInterface
      * {@inheritdoc}
      * @return \ArrayIterator<array-key, Node<TState>>
      */
-    public function getIterator(): iterable
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->nodes);
     }


### PR DESCRIPTION
Iterator Aggregate requires the getIterator() method to return Traversable, not iterable. See https://www.php.net/manual/en/class.iteratoraggregate.php
This fixes PHP 8.1 deprecation notices.